### PR TITLE
Add polars-upgrade pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.3
+    rev: v0.1.8
     hooks:
       - id: ruff
         types_or: [python, pyi, jupyter]
@@ -17,15 +17,20 @@ repos:
       - id: ruff-format
         types_or: [python, pyi, jupyter]
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: "1.3.0"
+    rev: 1.5.3
     hooks:
       - id: pyproject-fmt
+  - repo: https://github.com/MarcoGorelli/polars-upgrade/
+    rev: 0.1.19
+    hooks:
+      - id: polars-upgrade
+        args: [--target-version=0.19.15]
   - repo: https://github.com/abravalheri/validate-pyproject
     rev: v0.15
     hooks:
       - id: validate-pyproject
   - repo: https://github.com/commitizen-tools/commitizen
-    rev: 3.12.0
+    rev: v3.13.0
     hooks:
       - id: commitizen-branch
         stages: [push]


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.

Implements Marco Gorelli's excellent [polars-upgrade](https://github.com/MarcoGorelli/polars-upgrade) to always use the latest Polars syntax.

## Any other comments?

Given the frequency of the releases, this could be of great help.