### PR TITLE
Fix filename in API reference

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,7 +60,7 @@ nav:
     - forecasting: ref/forecasting.md
     - preprocessing: ref/preprocessing.md
     - seasonality: ref/seasonality.md
-    - feature_extraction: ref/feature-extraction.md
+    - feature_extraction: ref/feature-extractors.md
     - cross_validation: ref/cross-validation.md
     - offsets: ref/offsets.md
     - metrics: ref/metrics.md


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.

Rename `ref/feature-extraction.md` into `ref/feature-extractors.md` in mkdocs configurations.
