### PR TITLE
refactor: fix type hints of train_test_split

### DIFF
--- a/functime/cross_validation.py
+++ b/functime/cross_validation.py
@@ -27,7 +27,7 @@ def train_test_split(
 
     Returns
     -------
-    splitter : Callable[pl.LazyFrame | pl.DataFrame, Tuple[pl.LazyFrame, pl.LazyFrame]]
+    splitter : Callable[[pl.LazyFrame | pl.DataFrame], Tuple[pl.LazyFrame, pl.LazyFrame] | Tuple[pl.DataFrame, pl.DataFrame]]
         Function that takes a panel DataFrame or LazyFrame and returns tuple of train/test DataFrame or LazyFrame.
     """
 

--- a/functime/cross_validation.py
+++ b/functime/cross_validation.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from functools import partial
 from typing import TYPE_CHECKING, overload
 


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.

Fix the type annotations of train_test_split.

**Note**. Technically is a breaking change since I made `eager` a keyword only argument. If we plan to release in 0.10 we should mark it as such. Though I would assume that no one with benign intentions calls `train_test_split(4, true)`.
