### PR TITLE
build: remove bottleneck

### DIFF
--- a/functime/feature_extractors.py
+++ b/functime/feature_extractors.py
@@ -2,7 +2,6 @@ import logging
 import math
 from typing import List, Mapping, Optional, Sequence, Union
 
-# import bottleneck as bn
 import numpy as np
 import polars as pl
 from polars.type_aliases import ClosedInterval

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ classifiers = [
   "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-  "bottleneck",
   "dask",
   "flaml<3,>=2.0.2",
   "holidays",


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.

`bottleneck` is listed as dependency but used nowhere.
