### PR TITLE
Add float support in `train_test_split`

### DIFF
--- a/functime/cross_validation.py
+++ b/functime/cross_validation.py
@@ -11,8 +11,8 @@ def train_test_split(
 
     Parameters
     ----------
-    test_size : int
-        Number of test samples.
+    test_size : int | float
+        Number or fracetion of test samples.
     eager : bool
         If True, evaluate immediately and returns tuple of train-test `DataFrame`.
 
@@ -21,6 +21,14 @@ def train_test_split(
     splitter : Callable[pl.LazyFrame, Tuple[pl.LazyFrame, pl.LazyFrame]]
         Function that takes a panel LazyFrame and returns tuple of train / test LazyFrames.
     """
+    if isinstance(test_size, float):
+        if test_size < 0 or test_size > 1:
+            raise ValueError("`test_size` must be between 0 and 1")
+    elif isinstance(test_size, int):
+        if test_size < 0:
+            raise ValueError("`test_size` must be greater than 0")
+    else:
+        raise TypeError("`test_size` must be int or float")
 
     def split(X: pl.LazyFrame) -> pl.LazyFrame:
         train_length = (

--- a/functime/cross_validation.py
+++ b/functime/cross_validation.py
@@ -12,7 +12,7 @@ def train_test_split(
     Parameters
     ----------
     test_size : int | float
-        Number or fracetion of test samples.
+        Number or fraction of test samples.
     eager : bool
         If True, evaluate immediately and returns tuple of train-test `DataFrame`.
 


### PR DESCRIPTION
# Description

This is a first draft of how I would address and fix #167 to add support for float in `train_test_split`.
I noticed typing has some issues but it is already been addresses in #161.

Question: Would you like to have a default value (e.g. 25% as in scikit-learn) for the test size?
