### PR TITLE
fix: variable name typo in roll fill_strategy

### DIFF
--- a/functime/preprocessing.py
+++ b/functime/preprocessing.py
@@ -321,7 +321,7 @@ def roll(
         #     X_rolling.columns
         # )
         if fill_strategy:
-            X_rolling = X_X_rolling.fill_null(strategy=fill_strategy)
+            X_rolling = X_rolling.fill_null(strategy=fill_strategy)
         artifacts = {"X_new": X_rolling}
         return artifacts
 


### PR DESCRIPTION
## Reference Issues/PRs
Fixes #182 

## What does this implement/fix? Explain your changes.
Correcting the typo to avoid NameError when using fill_strategy in the roll function
