### PR TITLE
docs: Fix typo in docs/ref/forecasting.md

### DIFF
--- a/docs/ref/forecasting.md
+++ b/docs/ref/forecasting.md
@@ -1,6 +1,6 @@
 `functime` supports both individual forecasters and forecasters with automated lags / hyperparameter tuning.
 Auto-forecasters uses `FLAML` to optimize both hyperparameters and number of lagged dependent variables.
-`FLAML` is a [SOTA library](https://github.com/microsoft/FLAML) for automated hyperparameter tuning using the CFO (Frugal Optimization for Cost-related Hyperparamters[^1]) algorithm. All individual forecasters (e.g. `lasso` / `xgboost`) and automated forecasters (e.g. `auto_lasso` and `auto_xgboost`) implement the following API.
+`FLAML` is a [SOTA library](https://github.com/microsoft/FLAML) for automated hyperparameter tuning using the CFO (Frugal Optimization for Cost-related Hyperparameters[^1]) algorithm. All individual forecasters (e.g. `lasso` / `xgboost`) and automated forecasters (e.g. `auto_lasso` and `auto_xgboost`) implement the following API.
 
 ## `forecaster`
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/functime-org/functime/blob/main/CONTRIBUTING.md

👋 The best way to engage with us is to join our Discord channel:
https://discord.com/invite/JKMrZKjEwN
-->

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


## What does this implement/fix? Explain your changes.

Just fixed a typo in `docs/ref/forecasting.md`.


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are.

If we are slow to review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
