### PR TITLE
fix(206): Fix `ValueError` in `cwt_coefficients`

### DIFF
--- a/functime/feature_extractors.py
+++ b/functime/feature_extractors.py
@@ -592,10 +592,10 @@ def cwt_coefficients(
         for i, width in enumerate(widths):
             points = np.min([10 * width, x.len()])
             wavelet_x = np.conj(ricker(points, width)[::-1])
-            convolution[i] = np.convolve(x.to_numpy(zero_copy_only=True), wavelet_x)
+            convolution[i] = np.convolve(x.to_numpy(zero_copy_only=True), wavelet_x, mode="same")
         coeffs = []
         for coeff_idx in range(min(n_coefficients, convolution.shape[1])):
-            coeffs.extend(convolution[widths.index(), coeff_idx] for _ in widths)
+            coeffs.extend(convolution[widths.index(w), coeff_idx] for w in widths)
         return coeffs
     else:
         logger.info(

--- a/tests/test_feature_extractors.py
+++ b/tests/test_feature_extractors.py
@@ -1,0 +1,12 @@
+import numpy as np
+import polars as pl
+import pytest
+from functime.feature_extractors import cwt_coefficients
+
+
+@pytest.mark.parametrize("length", np.random.random_integers(low=1, high=100, size=5))
+@pytest.mark.parametrize("widths", [(2,), (2, 5, 10, 20), (2, 5, 10, 20, 30)])
+@pytest.mark.parametrize("n_coefficients", np.random.random_integers(low=1, high=100, size=5))
+def test_cwt(length: int, widths: tuple, n_coefficients: int) -> None:
+    out = cwt_coefficients(pl.Series([1 for _ in range(length)]), widths=widths, n_coefficients=n_coefficients)
+    assert len(out) == min(n_coefficients, length) * len(widths)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/functime-org/functime/blob/main/CONTRIBUTING.md

👋 The best way to engage with us is to join our Discord channel:
https://discord.com/invite/JKMrZKjEwN
-->

## Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Closes #206

## What does this implement/fix? Explain your changes.

- `cwt_coefficients` does not throw `ValueError` anymore.
- Now there is a minimal unit test for `cwt_coefficients`.

## Any other comments?

I am not 100% sure in the fix myself. I have compared with https://github.com/scipy/scipy/blob/v1.13.0/scipy/signal/_wavelets.py#L543 and with https://tsfresh.readthedocs.io/en/latest/_modules/tsfresh/feature_extraction/feature_calculators.html#cwt_coefficients. But I do not have time to validate the math with the code. I will need a very thorough review.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are.

If we are slow to review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
