### PR TITLE
refactor: Properly annotate `train_test_split`

### DIFF
--- a/functime/cross_validation.py
+++ b/functime/cross_validation.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, overload
 
 if TYPE_CHECKING:
     from typing import (
@@ -9,7 +9,6 @@ if TYPE_CHECKING:
         Optional,
         Tuple,
         Union,
-        overload,
     )
 
     from functime.type_aliases import EagerSplitter, LazySplitter, PolarsFrame

--- a/functime/cross_validation.py
+++ b/functime/cross_validation.py
@@ -1,14 +1,18 @@
 from __future__ import annotations
 
-from typing import (
-    Callable,
-    Literal,
-    Mapping,
-    Optional,
-    Tuple,
-    Union,
-    overload,
-)
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import (
+        Literal,
+        Mapping,
+        Optional,
+        Tuple,
+        Union,
+        overload,
+    )
+
+    from functime.type_aliases import EagerSplitter, LazySplitter, PolarsFrame
 
 import numpy as np
 import polars as pl
@@ -22,29 +26,29 @@ __all__ = [
 
 @overload
 def train_test_split(
-    test_size: int,
-    eager: Literal[True],
-) -> Callable[
-    [Union[pl.DataFrame, pl.LazyFrame]], Tuple[pl.DataFrame, pl.DataFrame]
-]: ...
+    test_size: Union[int, float] = ...,
+    eager: Literal[True] = ...,
+) -> EagerSplitter: ...
 
 
 @overload
 def train_test_split(
-    test_size: int,
-    eager: Literal[False],
-) -> Callable[
-    [Union[pl.DataFrame, pl.LazyFrame]], Tuple[pl.LazyFrame, pl.LazyFrame]
-]: ...
+    test_size: Union[int, float] = ...,
+    eager: Literal[False] = ...,
+) -> LazySplitter: ...
+
+
+@overload
+def train_test_split(
+    test_size: Union[int, float] = ...,
+    eager: bool = ...,
+) -> Union[EagerSplitter, LazySplitter]: ...
 
 
 def train_test_split(
     test_size: Union[int, float] = 0.25,
     eager: bool = False,
-) -> Callable[
-    [Union[pl.DataFrame, pl.LazyFrame]],
-    Union[Tuple[pl.DataFrame, pl.DataFrame], Tuple[pl.LazyFrame, pl.LazyFrame]],
-]:
+) -> Union[EagerSplitter, LazySplitter]:
     """Return a time-ordered train set and test set given `test_size`.
 
     Parameters
@@ -69,7 +73,7 @@ def train_test_split(
         raise TypeError("`test_size` must be int or float")
 
     def splitter(
-        X: Union[pl.DataFrame, pl.LazyFrame],
+        X: PolarsFrame,
     ) -> Union[Tuple[pl.DataFrame, pl.DataFrame], Tuple[pl.LazyFrame, pl.LazyFrame]]:
         return _splitter_train_test(
             X=X,
@@ -77,27 +81,35 @@ def train_test_split(
             eager=eager,
         )
 
-    return splitter
+    return splitter  # pyright: ignore[reportReturnType]
 
 
 @overload
 def _splitter_train_test(
-    X: Union[pl.DataFrame, pl.LazyFrame],
+    X: PolarsFrame,
     test_size: Union[int, float],
-    eager: Literal[True],
+    eager: Literal[True] = ...,
 ) -> Tuple[pl.DataFrame, pl.DataFrame]: ...
 
 
 @overload
 def _splitter_train_test(
-    X: Union[pl.DataFrame, pl.LazyFrame],
+    X: PolarsFrame,
     test_size: Union[int, float],
-    eager: Literal[False],
+    eager: Literal[False] = ...,
 ) -> Tuple[pl.LazyFrame, pl.LazyFrame]: ...
 
 
+@overload
 def _splitter_train_test(
-    X: Union[pl.DataFrame, pl.LazyFrame],
+    X: PolarsFrame,
+    test_size: Union[int, float],
+    eager: bool = ...,
+) -> Union[Tuple[pl.DataFrame, pl.DataFrame], Tuple[pl.LazyFrame, pl.LazyFrame]]: ...
+
+
+def _splitter_train_test(
+    X: PolarsFrame,
     test_size: Union[int, float],
     eager: bool = False,
 ) -> Union[Tuple[pl.DataFrame, pl.DataFrame], Tuple[pl.LazyFrame, pl.LazyFrame]]:

--- a/functime/cross_validation.py
+++ b/functime/cross_validation.py
@@ -1,14 +1,50 @@
 from __future__ import annotations
 
-from typing import Mapping, Optional, Tuple, Union
+from typing import (
+    Callable,
+    Literal,
+    Mapping,
+    Optional,
+    Tuple,
+    Union,
+    overload,
+)
 
 import numpy as np
 import polars as pl
 
+__all__ = [
+    "train_test_split",
+    "expanding_window_split",
+    "sliding_window_split",
+]
+
+
+@overload
+def train_test_split(
+    test_size: int,
+    eager: Literal[True],
+) -> Callable[
+    [Union[pl.DataFrame, pl.LazyFrame]], Tuple[pl.DataFrame, pl.DataFrame]
+]: ...
+
+
+@overload
+def train_test_split(
+    test_size: int,
+    eager: Literal[False],
+) -> Callable[
+    [Union[pl.DataFrame, pl.LazyFrame]], Tuple[pl.LazyFrame, pl.LazyFrame]
+]: ...
+
 
 def train_test_split(
-    test_size: Union[int, float] = 0.25, eager: bool = False
-) -> Tuple[pl.LazyFrame, pl.LazyFrame]:
+    test_size: Union[int, float] = 0.25,
+    eager: bool = False,
+) -> Callable[
+    [Union[pl.DataFrame, pl.LazyFrame]],
+    Union[Tuple[pl.DataFrame, pl.DataFrame], Tuple[pl.LazyFrame, pl.LazyFrame]],
+]:
     """Return a time-ordered train set and test set given `test_size`.
 
     Parameters
@@ -32,80 +68,71 @@ def train_test_split(
     else:
         raise TypeError("`test_size` must be int or float")
 
-    def split(X: pl.LazyFrame) -> pl.LazyFrame:
-        X = X.lazy()  # Defensive
-        entity_col = X.columns[0]
-
-        max_size = (
-            X.group_by(entity_col)
-            .agg(pl.count())
-            .select(pl.min("count"))
-            .collect()
-            .item()
+    def splitter(
+        X: Union[pl.DataFrame, pl.LazyFrame],
+    ) -> Union[Tuple[pl.DataFrame, pl.DataFrame], Tuple[pl.LazyFrame, pl.LazyFrame]]:
+        return _splitter_train_test(
+            X=X,
+            test_size=test_size,
+            eager=eager,
         )
-        if isinstance(test_size, int) and test_size > max_size:
-            raise ValueError(
-                "`test_size` must be less than the number of samples of the smallest entity"
-            )
 
-        train_length = (
-            pl.count() - test_size
-            if isinstance(test_size, int)
-            else (pl.count() * (1 - test_size)).cast(int)
-        )
-        test_length = pl.count() - train_length
-
-        train_split = (
-            X.group_by(entity_col)
-            .agg(pl.all().slice(offset=0, length=train_length))
-            .explode(pl.all().exclude(entity_col))
-        )
-        test_split = (
-            X.group_by(entity_col)
-            .agg(pl.all().slice(offset=train_length, length=test_length))
-            .explode(pl.all().exclude(entity_col))
-        )
-        if eager:
-            train_split, test_split = pl.collect_all([train_split, test_split])
-        return train_split, test_split
-
-    return split
+    return splitter
 
 
-def _window_split(
-    X: pl.LazyFrame,
-    test_size: int,
-    n_splits: int,
-    step_size: int,
-    window_size: Optional[int] = None,
-) -> Mapping[int, Tuple[pl.LazyFrame, pl.LazyFrame]]:
+@overload
+def _splitter_train_test(
+    X: Union[pl.DataFrame, pl.LazyFrame],
+    test_size: Union[int, float],
+    eager: Literal[True],
+) -> Tuple[pl.DataFrame, pl.DataFrame]: ...
+
+
+@overload
+def _splitter_train_test(
+    X: Union[pl.DataFrame, pl.LazyFrame],
+    test_size: Union[int, float],
+    eager: Literal[False],
+) -> Tuple[pl.LazyFrame, pl.LazyFrame]: ...
+
+
+def _splitter_train_test(
+    X: Union[pl.DataFrame, pl.LazyFrame],
+    test_size: Union[int, float],
+    eager: bool = False,
+) -> Union[Tuple[pl.DataFrame, pl.DataFrame], Tuple[pl.LazyFrame, pl.LazyFrame]]:
     X = X.lazy()  # Defensive
-    backward_steps = np.arange(1, n_splits) * step_size + test_size
-    cutoffs = np.flip(np.concatenate([np.array([test_size]), backward_steps]))
     entity_col = X.columns[0]
-    if window_size:
-        # Sliding window CV
-        train_exprs = [
-            pl.all().slice(pl.count() - cutoff - window_size, window_size)
-            for cutoff in cutoffs
-        ]
-    else:
-        # Expanding window CV
-        train_exprs = [pl.all().slice(0, pl.count() - cutoff) for cutoff in cutoffs]
 
-    test_exprs = [pl.all().slice(-cutoffs[i], test_size) for i in range(n_splits)]
-    train_test_exprs = zip(train_exprs, test_exprs)
-    splits = {}
-    for i, train_test_expr in enumerate(train_test_exprs):
-        train_expr, test_expr = train_test_expr
-        train_split = (
-            X.group_by(entity_col).agg(train_expr).explode(pl.all().exclude(entity_col))
+    max_size = (
+        X.group_by(entity_col).agg(pl.count()).select(pl.min("count")).collect().item()
+    )
+    if isinstance(test_size, int) and test_size > max_size:
+        raise ValueError(
+            "`test_size` must be less than the number of samples of the smallest entity"
         )
-        test_split = (
-            X.group_by(entity_col).agg(test_expr).explode(pl.all().exclude(entity_col))
-        )
-        splits[i] = train_split, test_split
-    return splits
+
+    train_length = (
+        pl.count() - test_size
+        if isinstance(test_size, int)
+        else (pl.count() * (1 - test_size)).cast(int)
+    )
+    test_length = pl.count() - train_length
+
+    train_split = (
+        X.group_by(entity_col)
+        .agg(pl.all().slice(offset=0, length=train_length))
+        .explode(pl.all().exclude(entity_col))
+    )
+    test_split = (
+        X.group_by(entity_col)
+        .agg(pl.all().slice(offset=train_length, length=test_length))
+        .explode(pl.all().exclude(entity_col))
+    )
+    if eager:
+        train_split, test_split = pl.collect_all([train_split, test_split])
+        return train_split, test_split
+    return train_split, test_split
 
 
 def expanding_window_split(
@@ -199,3 +226,42 @@ def sliding_window_split(
         return splits
 
     return split
+
+
+def _window_split(
+    X: pl.LazyFrame,
+    test_size: int,
+    n_splits: int,
+    step_size: int,
+    window_size: Optional[int] = None,
+) -> Mapping[int, Tuple[pl.LazyFrame, pl.LazyFrame]]:
+    X = X.lazy()  # Defensive
+    backward_steps = np.arange(1, n_splits) * step_size + test_size
+    cutoffs = np.flip(np.concatenate([np.array([test_size]), backward_steps]))
+    entity_col = X.columns[0]
+
+    # TODO: split in two functions?
+    if window_size:
+        # Sliding window CV
+        train_exprs = [
+            pl.all().slice(pl.count() - cutoff - window_size, window_size)
+            for cutoff in cutoffs
+        ]
+    else:
+        # Expanding window CV
+        train_exprs = [pl.all().slice(0, pl.count() - cutoff) for cutoff in cutoffs]
+
+    test_exprs = [pl.all().slice(-cutoffs[i], test_size) for i in range(n_splits)]
+    train_test_exprs = zip(train_exprs, test_exprs)
+
+    splits = {}
+    for i, train_test_expr in enumerate(train_test_exprs):
+        train_expr, test_expr = train_test_expr
+        train_split = (
+            X.group_by(entity_col).agg(train_expr).explode(pl.all().exclude(entity_col))
+        )
+        test_split = (
+            X.group_by(entity_col).agg(test_expr).explode(pl.all().exclude(entity_col))
+        )
+        splits[i] = train_split, test_split
+    return splits

--- a/functime/feature_extractors.py
+++ b/functime/feature_extractors.py
@@ -16,8 +16,7 @@ from scipy.spatial import KDTree
 
 from functime._functime_rust import rs_faer_lstsq1
 from functime._utils import UseAtOwnRisk
-
-from .type_alias import DetrendMethod
+from functime.type_aliases import DetrendMethod
 
 # from functime.feature_extractor import FeatureExtractor  # noqa: F401
 

--- a/functime/type_aliases.py
+++ b/functime/type_aliases.py
@@ -1,3 +1,5 @@
+"""Type aliases."""
+
 from __future__ import annotations
 
 import sys
@@ -9,4 +11,5 @@ else:  # 3.9
     from typing_extensions import TypeAlias
 
 
+# feature extraction
 DetrendMethod: TypeAlias = Literal["linear", "mean"]

--- a/functime/type_aliases.py
+++ b/functime/type_aliases.py
@@ -3,12 +3,31 @@
 from __future__ import annotations
 
 import sys
-from typing import Literal
+from typing import (
+    Callable,
+    Literal,
+    Tuple,
+    TypeAlias,
+    Union,
+)
+
+import polars as pl
 
 if sys.version_info >= (3, 10):
     from typing import TypeAlias
 else:  # 3.9
     from typing_extensions import TypeAlias
+
+# general
+PolarsFrame: TypeAlias = Union[pl.DataFrame, pl.LazyFrame]
+
+# cross validation
+EagerSplitter: TypeAlias = Callable[
+    [Union[pl.DataFrame, pl.LazyFrame]], Tuple[pl.DataFrame, pl.DataFrame]
+]
+LazySplitter: TypeAlias = Callable[
+    [Union[pl.DataFrame, pl.LazyFrame]], Tuple[pl.LazyFrame, pl.LazyFrame]
+]
 
 
 # feature extraction

--- a/functime/type_aliases.py
+++ b/functime/type_aliases.py
@@ -7,7 +7,6 @@ from typing import (
     Callable,
     Literal,
     Tuple,
-    TypeAlias,
     Union,
 )
 


### PR DESCRIPTION
This has been bugging me for a while. Though I can't get rid of one error:

![image](https://github.com/functime-org/functime/assets/57922983/c41b65e4-2d05-4757-8546-2a07acb3dbdb)

@FBruzzesi have any ideas? (Taking the liberty to tag @marcogorelli too, whom I know hates function overloads)