### PR TITLE
build: Bump to polars version 20.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
   "flaml<3,>=2.0.2",
   "holidays",
   "numpy",
-  "polars>=0.20.7",
+  "polars>=0.20.8",
   "scikit-learn<2,>=1.2.2",
   "scipy",
   "tqdm",


### PR DESCRIPTION
This fixes several instances of the following errors. Out of good measure, I guess it's safe to just bump the min version since we're going to drop support for the older versions of polars.

![image](https://github.com/functime-org/functime/assets/57922983/d8fe6fc4-e0b9-44f9-a354-64634b31461f)
