### PR TITLE
build: reorder dependency groups

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,14 +87,18 @@ doc = [
   "mkdocstrings-python",
 ]
 test = [
+  "functime[all]",
+  "pytest-cov>=5.0.0",
+  "pytest-benchmark",
+]
+benchmark = [
+  "functime[test]",
   "aeon<0.5.0",
-  "coverage[toml]",
   "joblib",
   "mlforecast==0.8.1",
   "pandas",
   "pyarrow",
   "pytest",
-  "pytest-benchmark",
   "pytest-memray",
   "pytest-timeout",
   "statsmodels",
@@ -152,11 +156,6 @@ markers = [
   "multivariate: marks multivariate forecast test",
 ]
 xfail_strict = true
-
-[tool.coverage.run]
-parallel = true
-source = ["tests", "functime"]
-context = '${CONTEXT}'
 
 [tool.pyright]
 exclude = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,11 +34,11 @@ classifiers = [
 requires-python = ">=3.8"
 dependencies = [
   "cloudpickle",
-  "flaml<3,>=2.0.2",
+  "flaml>=2.0.2",
   "holidays",
   "numpy",
   "polars>=0.20.8",
-  "scikit-learn<2,>=1.2.2",
+  "scikit-learn>=1.2.2",
   "scipy",
   "tqdm",
   'typing-extensions; python_version < "3.10"',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ tree = [
 ]
 llm = [
   "openai",
-  "tabulate",
+  "pandas",
   "tenacity",
   "tiktoken",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,11 +73,14 @@ llm = [
   "tenacity",
   "tiktoken",
 ]
+all = [
+  "functime[ann,tree,plot]",
+]
 
 # provisionally here until PEP 735 is approved: https://peps.python.org/pep-0735/
 dev = [
+  "functime[doc,test]",
   "pre-commit",
-  "functime[doc,plot,test]"
 ]
 doc = [
   "jupyterlab",


### PR DESCRIPTION
Because benchmark dependencies made it impossible to install on py3.12!