### PR TITLE
fix: Add % support for num_points param in plotting methods()

### DIFF
--- a/functime/_plotting.py
+++ b/functime/_plotting.py
@@ -173,7 +173,7 @@ class TimeSeriesDisplay:
         self: Self,
         *,
         data: pl.LazyFrame,
-        num_points: Optional[int] = None,
+        num_points: Optional[int | float] = None,
         name_on_hover: Optional[str] = None,
         legend_group: Optional[str] = None,
         **kwargs,
@@ -185,8 +185,9 @@ class TimeSeriesDisplay:
         data : pl.LazyFrame
             Panel LazyFrame time series data.
         num_points : Optional[int]
-            Number of data points to plot. If `None`, plot all points.
-            Defaults to `None`
+            Number of data points to plot. If `None`, plot all points. If a
+            float value is passed, plot the corresponding percentage of points.
+            Defaults to `None`.
         name_on_hover : Optional[str]
             Text that will be displayed on hover. Defaults to the name of the target column.
         legend_group : Optional[str]
@@ -216,6 +217,9 @@ class TimeSeriesDisplay:
             y = data
         else:
             y = data.filter(pl.col(entity_col).is_in(self.entities))
+
+        if isinstance(num_points, float):
+            num_points = int(num_points * y.select(pl.len()).collect().item())
 
         if num_points is not None:
             y = y.group_by(entity_col).tail(num_points)

--- a/functime/_plotting.py
+++ b/functime/_plotting.py
@@ -218,15 +218,15 @@ class TimeSeriesDisplay:
         else:
             y = data.filter(pl.col(entity_col).is_in(self.entities))
 
+        y = y.collect()
         if isinstance(num_points, float):
-            num_points = int(num_points * y.select(pl.len()).collect().item())
+            num_points = int(num_points * y.select(pl.len()).item())
 
-        if num_points is not None:
-            y = y.group_by(entity_col).tail(num_points)
+        y = y.group_by(entity_col).tail(num_points)
 
         self.figure = add_traces(
             figure=self.figure,
-            y=y.collect(),
+            y=y,
             name_on_hover=name_on_hover,
             legend_group=legend_group,
             num_cols=self.num_cols,

--- a/functime/_plotting.py
+++ b/functime/_plotting.py
@@ -220,7 +220,12 @@ class TimeSeriesDisplay:
 
         y = y.collect()
         if isinstance(num_points, float):
-            num_points = int(num_points * y.select(pl.len()).item())
+            num_points = num_points * y.select(pl.len()).item()
+            num_points = (
+                int(num_points)
+                if num_points == int(num_points)
+                else int(num_points) + 1
+            )
 
         y = y.group_by(entity_col).tail(num_points)
 

--- a/functime/plotting.py
+++ b/functime/plotting.py
@@ -67,7 +67,7 @@ def plot_panel(
     *,
     num_series: Optional[int] = None,
     num_cols: Optional[int] = None,
-    num_points: Optional[int] = None,
+    num_points: Optional[int | float] = None,
     seed: Optional[int] = None,
     layout_kwargs: Optional[Dict[str, Any]] = None,
     line_kwargs: Optional[Dict[str, Any]] = None,
@@ -82,8 +82,9 @@ def plot_panel(
     num_series : Optional[int]
         Number of entities / time-series to plot. If `None`, plot all entities.
         Defaults to `None`.
-    num_points : Optional[int]
+    num_points : Optional[int | float]
         Plot `last_n` most recent values in `y`. If `None`, plot all points.
+        If a float value is passed, plot the correspinding percentage of the points.
         Defaults to `None`.
     num_cols : Optional[int]
         Number of columns to arrange subplots. Defaults to 2.
@@ -127,7 +128,7 @@ def plot_forecasts(
     y_pred: Union[pl.DataFrame, pl.LazyFrame],
     num_series: Optional[int] = None,
     num_cols: Optional[int] = None,
-    num_points: Optional[int] = None,
+    num_points: Optional[int | float] = None,
     seed: Optional[int] = None,
     layout_kwargs: Optional[Dict[str, Any]] = None,
     line_kwargs: Optional[Dict[str, Any]] = None,
@@ -144,6 +145,7 @@ def plot_forecasts(
         Defaults to `None`.
     num_points : Optional[int]
         Plot `last_n` most recent values in `y`. If `None`, plot all points.
+        If a float value is passed, plot the correspinding percentage of the points.
         Defaults to `None`.
     num_cols : Optional[int]
         Number of columns to arrange subplots. Defaults to 2.
@@ -200,7 +202,7 @@ def plot_backtests(
     *,
     num_series: Optional[int] = None,
     num_cols: Optional[int] = None,
-    num_points: Optional[int] = None,
+    num_points: Optional[int | float] = None,
     seed: Optional[int] = None,
     layout_kwargs: Optional[Dict[str, Any]] = None,
     line_kwargs: Optional[Dict[str, Any]] = None,


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/functime-org/functime/blob/main/CONTRIBUTING.md

👋 The best way to engage with us is to join our Discord channel:
https://discord.com/invite/JKMrZKjEwN
-->

## Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #236. 


## What does this implement/fix? Explain your changes.
`num_points` in plotting methods now is either float or int, and behaves accordingly.
If it's a float, the number of selected points is computed as:
`ceil(num_points * y.select(pl.len()).item())`


## Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are.

If we are slow to review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
I'm not sure how to write unit tests (and if they are necessary) for this feature, as it's just a small math computation.