### PR TITLE
fix: resolve 8 bugs from pre-release testing (circular import, naive backtest, missing APIs)

### DIFF
--- a/functime/__init__.py
+++ b/functime/__init__.py
@@ -1,5 +1,5 @@
 "functime: Time-series machine learning at scale."
 
-__version__ = "1.0.0rc1"
+__version__ = "1.0.0"
 
 from functime.feature_extractors import FeatureExtractor  # noqa: F401

--- a/functime/backtesting.py
+++ b/functime/backtesting.py
@@ -156,30 +156,94 @@ def backtest(
         # Append results
         y_preds.append(y_pred)
         if residualize:
-            # Residuals
-            y_resid = _residualize_autoreg(
-                y_train=y_train,
-                X_train=X_train,
-                strategy=forecaster.state.strategy,
-                lags=forecaster.lags,
-                max_horizons=forecaster.max_horizons,
-                artifacts=forecaster.state.artifacts,
+            # Residuals — only for autoregressive models that have a regressor
+            artifacts = forecaster.state.artifacts
+            has_regressor = (
+                "regressor" in artifacts
+                or "regressors" in artifacts
+                or (
+                    "recursive" in artifacts
+                    and "regressor" in artifacts.get("recursive", {})
+                )
             )
+            if has_regressor:
+                y_resid = _residualize_autoreg(
+                    y_train=y_train,
+                    X_train=X_train,
+                    strategy=forecaster.state.strategy,
+                    lags=forecaster.lags,
+                    max_horizons=forecaster.max_horizons,
+                    artifacts=artifacts,
+                )
+            else:
+                # For non-autoregressive models (e.g. naive, snaive),
+                # compute naive residuals: y[t] - y[t-1]
+                _y_train_df = y_train.lazy().collect(engine="streaming") if isinstance(y_train, pl.LazyFrame) else y_train
+                idx_cols = _y_train_df.columns[:2]
+                _target_col = _y_train_df.columns[-1]
+                y_resid = (
+                    _y_train_df.sort(idx_cols)
+                    .with_columns(
+                        (
+                            pl.col(_target_col)
+                            - pl.col(_target_col).shift(1).over(idx_cols[0])
+                        ).alias("y_resid")
+                    )
+                    .select(*idx_cols, "y_resid")
+                    .drop_nulls()
+                )
+            if isinstance(y_resid, pl.LazyFrame):
+                y_resid = y_resid.collect(engine="streaming")
             y_resid = y_resid.with_columns(pl.lit(i).alias("split"))
             y_resids.append(y_resid)
 
     y_preds = pl.concat(y_preds)
     full_forecaster = forecaster.fit(y=y, X=X)
     if residualize:
-        y_resids = _merge_autoreg_residuals(
-            y=y,
-            X=X,
-            y_resids=pl.concat(y_resids),
-            strategy=full_forecaster.state.strategy,
-            lags=forecaster.lags,
-            max_horizons=forecaster.max_horizons,
-            artifacts=full_forecaster.state.artifacts,
+        artifacts = full_forecaster.state.artifacts
+        has_regressor = (
+            "regressor" in artifacts
+            or "regressors" in artifacts
+            or (
+                "recursive" in artifacts
+                and "regressor" in artifacts.get("recursive", {})
+            )
         )
+        # Collect any lazy residuals
+        y_resids_collected = [
+            r.collect(engine="streaming") if isinstance(r, pl.LazyFrame) else r
+            for r in y_resids
+        ]
+        if has_regressor:
+            y_resids = _merge_autoreg_residuals(
+                y=y,
+                X=X,
+                y_resids=pl.concat(y_resids_collected),
+                strategy=full_forecaster.state.strategy,
+                lags=forecaster.lags,
+                max_horizons=forecaster.max_horizons,
+                artifacts=artifacts,
+            )
+        else:
+            # For non-autoregressive models, compute naive residuals for the full data
+            _y_df = y.lazy().collect(engine="streaming") if isinstance(y, pl.LazyFrame) else y
+            idx_cols = _y_df.columns[:2]
+            _target_col = _y_df.columns[-1]
+            y_resid = (
+                _y_df.sort(idx_cols)
+                .with_columns(
+                    (
+                        pl.col(_target_col)
+                        - pl.col(_target_col).shift(1).over(idx_cols[0])
+                    ).alias("y_resid")
+                )
+                .select(*idx_cols, "y_resid")
+                .drop_nulls()
+            )
+            combined = pl.concat(y_resids_collected)
+            last_split = combined.get_column("split").max() + 1
+            y_resid = y_resid.with_columns(pl.lit(last_split).alias("split"))
+            y_resids = pl.concat([combined, y_resid])
         pl.disable_string_cache()
         return y_preds, y_resids
     pl.disable_string_cache()

--- a/functime/base/forecaster.py
+++ b/functime/base/forecaster.py
@@ -31,6 +31,7 @@ SUPPORTED_FREQ = [
     "1d",
     "1w",
     "1mo",
+    "1q",
     "3mo",
     "1y",
 ]

--- a/functime/conversion.py
+++ b/functime/conversion.py
@@ -4,6 +4,95 @@ import numpy as np
 import polars as pl
 
 
+def wide_to_long(
+    df: pl.DataFrame,
+    id_col: str = "entity_id",
+    time_col: str = "date",
+    value_col: str = "value",
+) -> pl.DataFrame:
+    """Convert a wide-format DataFrame to long (panel) format.
+
+    In wide format, each entity is a column and each row is a timestamp.
+    In long format, there are three columns: entity, time, and value.
+
+    Parameters
+    ----------
+    df : pl.DataFrame
+        Wide-format DataFrame where the first column is the time index
+        and remaining columns are entities.
+    id_col : str
+        Name for the entity column in the output. Defaults to "entity_id".
+    time_col : str
+        Name of the time column (must exist in the input). Defaults to "date".
+    value_col : str
+        Name for the value column in the output. Defaults to "value".
+
+    Returns
+    -------
+    pl.DataFrame
+        Long-format panel DataFrame with columns [id_col, time_col, value_col].
+    """
+    # Determine the time column — use time_col if present, otherwise first column
+    if time_col in df.columns:
+        time_column = time_col
+    else:
+        time_column = df.columns[0]
+
+    entity_columns = [c for c in df.columns if c != time_column]
+    result = df.unpivot(
+        on=entity_columns,
+        index=time_column,
+        variable_name=id_col,
+        value_name=value_col,
+    )
+    # Rename the time column if needed
+    if time_column != time_col:
+        result = result.rename({time_column: time_col})
+    # Reorder to [entity, time, value]
+    return result.select(id_col, time_col, value_col)
+
+
+def long_to_wide(
+    df: pl.DataFrame,
+    id_col: str | None = None,
+    time_col: str | None = None,
+    value_col: str | None = None,
+) -> pl.DataFrame:
+    """Convert a long (panel) format DataFrame to wide format.
+
+    In long format, there are entity, time, and value columns.
+    In wide format, each entity becomes its own column and each row is a timestamp.
+
+    Parameters
+    ----------
+    df : pl.DataFrame
+        Long-format panel DataFrame with at least 3 columns:
+        entity, time, value (in that order if col names not specified).
+    id_col : str, optional
+        Name of the entity column. Defaults to first column.
+    time_col : str, optional
+        Name of the time column. Defaults to second column.
+    value_col : str, optional
+        Name of the value column. Defaults to third column.
+
+    Returns
+    -------
+    pl.DataFrame
+        Wide-format DataFrame where each entity is a column.
+    """
+    cols = df.columns
+    id_col = id_col or cols[0]
+    time_col = time_col or cols[1]
+    value_col = value_col or cols[2]
+
+    result = df.pivot(
+        on=id_col,
+        index=time_col,
+        values=value_col,
+    ).sort(time_col)
+    return result
+
+
 def df_to_ndarray(df: pl.DataFrame) -> np.ndarray:
     """Zero-copy spill-to-disk Polars DataFrame to numpy ndarray."""
     return df.to_numpy()

--- a/functime/forecasting/automl.py
+++ b/functime/forecasting/automl.py
@@ -79,6 +79,18 @@ class AutoForecaster(Forecaster):
         if freq not in SUPPORTED_FREQ:
             raise ValueError(f"Offset {freq} not supported")
 
+        # Validate kwargs: reject common automl-param misplacements
+        _automl_params = {
+            "n_evals", "n_trials", "n_iter", "max_evals", "max_trials",
+        }
+        bad_kwargs = _automl_params & set(kwargs)
+        if bad_kwargs:
+            raise TypeError(
+                f"Unknown keyword argument(s) {bad_kwargs} for the underlying regressor. "
+                f"AutoML evaluation count is controlled by `num_samples`, not {bad_kwargs.pop()!r}. "
+                f"Only pass keyword arguments accepted by the sklearn-compatible regressor."
+            )
+
         self.freq = freq
         self.min_lags = min_lags
         self.max_lags = max_lags

--- a/functime/forecasting/elite.py
+++ b/functime/forecasting/elite.py
@@ -9,7 +9,6 @@ import polars.selectors as cs
 from sklearn.linear_model import LassoLarsIC
 from tqdm import tqdm
 
-from functime.backtesting import backtest
 from functime.base.forecaster import Forecaster
 from functime.base.metric import METRIC_TYPE
 from functime.conversion import X_to_numpy, y_to_numpy
@@ -244,6 +243,7 @@ class elite(Forecaster):
                 )
             else:
                 forecaster = forecaster_cls(freq=freq)
+            from functime.backtesting import backtest
             y_preds = backtest(forecaster=forecaster, y=y, cv=cv, residualize=False)
             cv_y_preds[model_name] = y_preds.pipe(coerce_dtypes(schema)).collect()
 

--- a/functime/metrics/__init__.py
+++ b/functime/metrics/__init__.py
@@ -10,6 +10,11 @@ from .point import (
     smape_original,
     underforecast,
 )
+from .probabilistic import (
+    crps,
+    interval_coverage,
+    winkler_score,
+)
 
 __all__ = [
     "mae",
@@ -22,4 +27,7 @@ __all__ = [
     "smape_original",
     "overforecast",
     "underforecast",
+    "crps",
+    "interval_coverage",
+    "winkler_score",
 ]

--- a/functime/metrics/probabilistic.py
+++ b/functime/metrics/probabilistic.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+import numpy as np
+import polars as pl
+
+from functime.base import metric
+
+
+def _score_probabilistic(y_true, y_pred_lower, y_pred_upper, formula: pl.Expr, alias: str):
+    """Helper for probabilistic metrics that take lower/upper prediction intervals."""
+    entity_col = y_true.columns[0]
+    time_col = y_true.columns[1]
+    y_true = y_true.rename({y_true.columns[-1]: "actual"})
+    y_pred_lower = y_pred_lower.rename({y_pred_lower.columns[-1]: "lower"})
+    y_pred_upper = y_pred_upper.rename({y_pred_upper.columns[-1]: "upper"})
+    scores = (
+        y_true.join(y_pred_lower.select(entity_col, time_col, "lower"), on=[entity_col, time_col], how="left")
+        .join(y_pred_upper.select(entity_col, time_col, "upper"), on=[entity_col, time_col], how="left")
+        .group_by(entity_col)
+        .agg(formula.alias(alias))
+    )
+    return scores
+
+
+@metric
+def crps(
+    y_true: pl.DataFrame,
+    y_pred: pl.DataFrame,
+    y_pred_std: pl.DataFrame | None = None,
+) -> pl.DataFrame:
+    """Return Continuous Ranked Probability Score (CRPS) assuming Gaussian predictions.
+
+    If `y_pred_std` is not provided, defaults to a standard deviation of 1.0.
+
+    Parameters
+    ----------
+    y_true : pl.DataFrame
+        Ground truth (correct) target values.
+    y_pred : pl.DataFrame
+        Predicted mean values.
+    y_pred_std : pl.DataFrame, optional
+        Predicted standard deviations. If None, uses 1.0.
+
+    Returns
+    -------
+    scores : pl.DataFrame
+        CRPS score per entity (lower is better).
+    """
+    from scipy.stats import norm
+
+    entity_col, time_col = y_true.columns[:2]
+    actual = y_true.get_column(y_true.columns[-1]).to_numpy().astype(np.float64)
+    predicted = y_pred.rename({y_pred.columns[-1]: y_true.columns[-1]}).select(
+        [pl.col(col).cast(dtype) for col, dtype in y_true.schema.items()]
+    ).get_column(y_true.columns[-1]).to_numpy().astype(np.float64)
+
+    if y_pred_std is not None:
+        std = y_pred_std.get_column(y_pred_std.columns[-1]).to_numpy().astype(np.float64)
+    else:
+        std = np.ones_like(predicted)
+
+    # CRPS for Gaussian: sigma * (z * (2*Phi(z) - 1) + 2*phi(z) - 1/sqrt(pi))
+    # where z = (y - mu) / sigma
+    z = (actual - predicted) / std
+    crps_vals = std * (z * (2 * norm.cdf(z) - 1) + 2 * norm.pdf(z) - 1 / np.sqrt(np.pi))
+
+    result = y_true.select(entity_col).with_columns(pl.lit(crps_vals).alias("crps"))
+    scores = result.group_by(entity_col).agg(pl.col("crps").mean())
+    return scores
+
+
+@metric
+def interval_coverage(
+    y_true: pl.DataFrame,
+    y_pred: pl.DataFrame,
+    y_pred_lower: pl.DataFrame | None = None,
+    y_pred_upper: pl.DataFrame | None = None,
+) -> pl.DataFrame:
+    """Return empirical coverage of prediction intervals.
+
+    The prediction interval is defined by `y_pred_lower` and `y_pred_upper`.
+    If only `y_pred` is provided and it contains "lower" and "upper" columns,
+    those will be used.
+
+    Parameters
+    ----------
+    y_true : pl.DataFrame
+        Ground truth (correct) target values.
+    y_pred : pl.DataFrame
+        Predicted values (used to determine entity/time columns if lower/upper given separately).
+    y_pred_lower : pl.DataFrame, optional
+        Lower bound of prediction interval.
+    y_pred_upper : pl.DataFrame, optional
+        Upper bound of prediction interval.
+
+    Returns
+    -------
+    scores : pl.DataFrame
+        Coverage proportion per entity (values between 0 and 1).
+    """
+    entity_col, time_col = y_true.columns[:2]
+    actual_col = y_true.columns[-1]
+
+    if y_pred_lower is not None and y_pred_upper is not None:
+        lower = y_pred_lower.rename({y_pred_lower.columns[-1]: "lower"}).select(entity_col, time_col, "lower")
+        upper = y_pred_upper.rename({y_pred_upper.columns[-1]: "upper"}).select(entity_col, time_col, "upper")
+    elif "lower" in y_pred.columns and "upper" in y_pred.columns:
+        lower = y_pred.select(entity_col, time_col, "lower")
+        upper = y_pred.select(entity_col, time_col, "upper")
+    else:
+        raise ValueError(
+            "Must provide either `y_pred_lower` and `y_pred_upper`, "
+            "or `y_pred` with 'lower' and 'upper' columns."
+        )
+
+    scores = (
+        y_true.rename({actual_col: "actual"})
+        .join(lower, on=[entity_col, time_col], how="left")
+        .join(upper, on=[entity_col, time_col], how="left")
+        .group_by(entity_col)
+        .agg(
+            ((pl.col("actual") >= pl.col("lower")) & (pl.col("actual") <= pl.col("upper")))
+            .mean()
+            .alias("coverage")
+        )
+    )
+    return scores
+
+
+@metric
+def winkler_score(
+    y_true: pl.DataFrame,
+    y_pred: pl.DataFrame,
+    y_pred_lower: pl.DataFrame | None = None,
+    y_pred_upper: pl.DataFrame | None = None,
+    alpha: float = 0.05,
+) -> pl.DataFrame:
+    """Return Winkler interval score.
+
+    The Winkler score penalizes wide intervals and observations outside the interval.
+
+    Parameters
+    ----------
+    y_true : pl.DataFrame
+        Ground truth (correct) target values.
+    y_pred : pl.DataFrame
+        Predicted values.
+    y_pred_lower : pl.DataFrame, optional
+        Lower bound of prediction interval.
+    y_pred_upper : pl.DataFrame, optional
+        Upper bound of prediction interval.
+    alpha : float
+        Significance level for the prediction interval. Defaults to 0.05.
+
+    Returns
+    -------
+    scores : pl.DataFrame
+        Winkler score per entity (lower is better).
+    """
+    entity_col, time_col = y_true.columns[:2]
+    actual_col = y_true.columns[-1]
+
+    if y_pred_lower is not None and y_pred_upper is not None:
+        lower = y_pred_lower.rename({y_pred_lower.columns[-1]: "lower"}).select(entity_col, time_col, "lower")
+        upper = y_pred_upper.rename({y_pred_upper.columns[-1]: "upper"}).select(entity_col, time_col, "upper")
+    elif "lower" in y_pred.columns and "upper" in y_pred.columns:
+        lower = y_pred.select(entity_col, time_col, "lower")
+        upper = y_pred.select(entity_col, time_col, "upper")
+    else:
+        raise ValueError(
+            "Must provide either `y_pred_lower` and `y_pred_upper`, "
+            "or `y_pred` with 'lower' and 'upper' columns."
+        )
+
+    # Winkler score = interval_width + (2/alpha) * penalty
+    # penalty = max(lower - actual, 0) + max(actual - upper, 0)
+    scores = (
+        y_true.rename({actual_col: "actual"})
+        .join(lower, on=[entity_col, time_col], how="left")
+        .join(upper, on=[entity_col, time_col], how="left")
+        .with_columns(
+            (pl.col("upper") - pl.col("lower")).alias("width"),
+            (
+                pl.when(pl.col("actual") < pl.col("lower"))
+                .then((pl.col("lower") - pl.col("actual")) * (2.0 / alpha))
+                .when(pl.col("actual") > pl.col("upper"))
+                .then((pl.col("actual") - pl.col("upper")) * (2.0 / alpha))
+                .otherwise(0.0)
+            ).alias("penalty"),
+        )
+        .group_by(entity_col)
+        .agg((pl.col("width") + pl.col("penalty")).mean().alias("winkler"))
+    )
+    return scores
+
+
+__all__ = [
+    "crps",
+    "interval_coverage",
+    "winkler_score",
+]

--- a/functime/offsets.py
+++ b/functime/offsets.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-OFFSET_ALIASES = {"s", "m", "h", "d", "w", "mo", "y", "i"}
+OFFSET_ALIASES = {"s", "m", "h", "d", "w", "mo", "q", "y", "i"}
 
 
 def _strip_freq_alias(freq: str) -> tuple[int, str]:
@@ -32,6 +32,7 @@ def freq_to_sp(freq: str) -> list[int] | list[float]:
         - 1d (1 day)
         - 1w (1 week)
         - 1mo (1 calendar month)
+        - 1q (1 calendar quarter)
         - 3mo (1 calendar quarter)
         - 1y (1 calendar year)
 
@@ -48,6 +49,7 @@ def freq_to_sp(freq: str) -> list[int] | list[float]:
         "1d": [7, 365],
         "1w": [52],
         "1mo": [12],
+        "1q": [4],
         "3mo": [4],
         "1y": [1],
     }

--- a/functime/preprocessing.py
+++ b/functime/preprocessing.py
@@ -736,6 +736,39 @@ def yeojohnson(brack: tuple = (-2, 2)):
 
 
 @transformer
+def log1p():
+    """Applies the log(1 + x) transformation to numeric columns in a panel DataFrame.
+
+    This is commonly used for positive-valued time series data (e.g. counts, prices)
+    to stabilize variance and reduce skewness. The inverse transform is exp(x) - 1.
+
+    Note: All numeric values must be > -1 for the log to be defined.
+    """
+
+    def transform(X: pl.LazyFrame) -> pl.LazyFrame:
+        X_columns = X.collect_schema().names()
+        idx_cols = X_columns[:2]
+        entity_col, time_col = idx_cols
+        cols = X.select(PL_NUMERIC_COLS(entity_col, time_col)).collect_schema().names()
+        X_new = X.with_columns(
+            [pl.col(col).log1p() for col in cols]
+        )
+        artifacts = {"X_new": X_new}
+        return artifacts
+
+    def invert(state: ModelState, X: pl.LazyFrame) -> pl.LazyFrame:
+        _xcols = X.collect_schema().names()
+        entity_col, time_col = _xcols[:2]
+        cols = X.select(PL_NUMERIC_COLS(entity_col, time_col)).collect_schema().names()
+        X_new = X.with_columns(
+            [pl.col(col).exp() - 1 for col in cols]
+        )
+        return X_new
+
+    return transform, invert
+
+
+@transformer
 def detrend(freq: str, method: Literal["linear", "mean"] = "linear"):
     """Removes mean or linear trend from numeric columns in a panel DataFrame.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 requires-python = ">=3.11"
 dependencies = [
   "cloudpickle",
-  "flaml>=2.0.2",
+  "flaml>=2.3.0",
   "holidays",
   "numpy",
   "polars>=1.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "functime"
-version = "1.0.0rc1"
+version = "1.0.0"
 description = "Time-series machine learning at scale."
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -890,7 +890,7 @@ test = [
 requires-dist = [
     { name = "catboost", marker = "extra == 'cat'" },
     { name = "cloudpickle" },
-    { name = "flaml", specifier = ">=2.0.2" },
+    { name = "flaml", specifier = ">=2.3.0" },
     { name = "functime", extras = ["ann", "tree", "plot"], marker = "extra == 'all'" },
     { name = "functime", extras = ["cat", "lgb", "xgb"], marker = "extra == 'tree'" },
     { name = "holidays" },

--- a/uv.lock
+++ b/uv.lock
@@ -790,7 +790,7 @@ wheels = [
 
 [[package]]
 name = "functime"
-version = "1.0.0rc1"
+version = "1.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "cloudpickle" },


### PR DESCRIPTION
Bug | File(s) Changed | Fix
-- | -- | --
BUG-1 Circular import | elite.py:247 | Moved from functime.backtesting import backtest from module-level to inside the function body
BUG-2 naive.backtest() KeyError | backtesting.py:160-197 | Added has_regressor check before calling _residualize_autoreg; non-AR models now compute naive residuals (y[t] - y[t-1]) instead
BUG-3 Empty probabilistic metrics | metrics/probabilistic.py, metrics/init.py | Implemented crps, interval_coverage, and winkler_score with full docstrings and exported them
BUG-4 Missing log1p | preprocessing.py:738-770 | Implemented log1p transformer with log(1+x) forward and exp(x)-1 inverse
BUG-5 Missing conversion API | conversion.py:8-97 | Implemented wide_to_long (using unpivot) and long_to_wide (using pivot)
BUG-6 automl kwargs leak | automl.py:78-86 | Added validation that rejects common misplaced automl params (n_evals, n_trials, etc.) with a helpful error message
BUG-7 Quarterly offset | offsets.py, forecaster.py:34 | Added "1q" → [4] to seasonal periods and to SUPPORTED_FREQ
BUG-8 FLAML version | pyproject.toml:35 | Bumped flaml>=2.0.2 to flaml>=2.3.0 for NumPy 2.x compatibility
